### PR TITLE
Allow partial specification of options

### DIFF
--- a/src/http-data-source.ts
+++ b/src/http-data-source.ts
@@ -30,8 +30,8 @@ export interface LRUOptions {
 }
 
 export interface HTTPDataSourceOptions {
-  requestOptions?: RequestOptions
-  lru?: LRUOptions
+  requestOptions?: Partial<RequestOptions>
+  lru?: Partial<LRUOptions>
 }
 
 function apolloKeyValueCacheToKeyv(cache: KeyValueCache): Store<string> {


### PR DESCRIPTION
Works well but Typescript was not happy about the constructor 


```typescript
constructor() {
  super({
    requestOptions: {
      responseType: "text"
    }
});

```

Because the RequestOptions type included a lot of non optional members it wanted me to add all the missing parameters that I didn't want to override.

This pull request marks the HTTPDataSourceOptions with Partial versions of requestOptions and lru.
