### PR TITLE
fix-missing-request-option-type

### DIFF
--- a/src/http-data-source.ts
+++ b/src/http-data-source.ts
@@ -229,7 +229,7 @@ export abstract class HTTPDataSource<TContext = any> extends DataSource {
   }
 
   private async performRequest<TResult>(
-    options: Request,
+    options: Request & RequestOptions,
     cacheKey: string,
   ): Promise<Response<TResult>> {
     this.onRequest?.(options)
@@ -297,7 +297,7 @@ export abstract class HTTPDataSource<TContext = any> extends DataSource {
     }
   }
 
-  private async request<TResult = unknown>(request: Request): Promise<Response<TResult>> {
+  private async request<TResult = unknown>(request: Request & RequestOptions): Promise<Response<TResult>> {
     if (request?.query) {
       request.path = request.path + '?' + this.buildQueryString(request.query)
     }


### PR DESCRIPTION
Hi again,

I have another pull request but while creating it I found that the request options were not "available" to the request and performRequest functions via typescript parameter types. 

This pull request just fixes the missing types from the two request functions.

Thanks,
John