### PR TITLE
Allow dependent to upgrade to Apollo@3 and GraphQL@16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -858,22 +858,52 @@
       }
     },
     "apollo-datasource-rest": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-0.14.0.tgz",
-      "integrity": "sha512-OXh+kbpZPx0F5fNJLYmxIa8Nt+UIC7oK1pnoWtLMDws9/TiICaG6J7SHHAKnz03ZVnZ4XE9gKtm9RTCjCYJtSw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-3.4.0.tgz",
+      "integrity": "sha512-biv7jKykXV1g9Ans5FEUOTxpN7hx+ii5xMjI5wDUyqj0eFalU6Zry/7DFGVxTelHUcemoVKFTeHJb6lz80mxrg==",
       "dev": true,
       "requires": {
-        "apollo-datasource": "^0.9.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0",
-        "apollo-server-errors": "^2.5.0",
-        "http-cache-semantics": "^4.0.0"
+        "apollo-datasource": "^3.3.0",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0",
+        "apollo-server-errors": "^3.3.0",
+        "http-cache-semantics": "^4.1.0"
+      },
+      "dependencies": {
+        "apollo-datasource": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.0.tgz",
+          "integrity": "sha512-It8POTZTOCAnedRj2izEVeySN06LIfojigZjWaOY7voLe0DIgtvhql91xr27fuIWsR/Ew9twO3dLBjjvy34J4Q==",
+          "dev": true,
+          "requires": {
+            "apollo-server-caching": "^3.3.0",
+            "apollo-server-env": "^4.2.0"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+          "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.0.tgz",
+          "integrity": "sha512-4xJ+PCoWsFLj4rU6iXrIhqD7nI42goi4Iqrhsof9680ljSzkzd+PCwZsja3mHOFXKUQQUvJ7StVSgwaiRu45+A==",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^2.6.1"
+          }
+        }
       }
     },
     "apollo-reporting-protobuf": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
-      "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.2.0.tgz",
+      "integrity": "sha512-2v/5IRJeTGakCJo8kS2LeKUcLsgqxO/HpEyu1EaW79F0CsvrIk10tOIGxouoOgtVl5e1wfGePJ849CUWWczx2A==",
       "requires": {
         "@apollo/protobufjs": "1.2.2"
       }
@@ -896,18 +926,36 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.0.tgz",
+      "integrity": "sha512-9/MNlPZBbEjcCdJcUSbKbVEBT9xZS8GSpX7T/TyzcxHSbsXJszSDSipQNGC+PRKTKAUnv61IONScVyLKEZ5XEQ=="
     },
     "apollo-server-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
-      "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.4.0.tgz",
+      "integrity": "sha512-iFNRENtxDoFWoY+KxpGP+TYyRnqUPqUTubMJVgiXPDvOPFL8dzqGGmqq1g/VCeWFHRJTPBLWhOfQU7ktwDEjnQ==",
       "requires": {
-        "apollo-reporting-protobuf": "^0.8.0",
-        "apollo-server-caching": "^0.7.0",
-        "apollo-server-env": "^3.1.0"
+        "apollo-reporting-protobuf": "^3.2.0",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0"
+      },
+      "dependencies": {
+        "apollo-server-caching": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+          "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.0.tgz",
+          "integrity": "sha512-4xJ+PCoWsFLj4rU6iXrIhqD7nI42goi4Iqrhsof9680ljSzkzd+PCwZsja3mHOFXKUQQUvJ7StVSgwaiRu45+A==",
+          "requires": {
+            "node-fetch": "^2.6.1"
+          }
+        }
       }
     },
     "append-transform": {
@@ -2152,9 +2200,10 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw=="
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.2.0.tgz",
+      "integrity": "sha512-MuQd7XXrdOcmfwuLwC2jNvx0n3rxIuNYOxUtiee5XOmfrWo613ar2U8pE7aHAKh8VwfpifubpD9IP+EdEAEOsA==",
+      "dev": true
     },
     "h2url": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -52,17 +52,20 @@
     "@alloc/quick-lru": "^5.2.0",
     "apollo-datasource": "^0.9.0",
     "apollo-server-caching": "^0.7.0",
-    "apollo-server-errors": "^2.5.0",
-    "apollo-server-types": "^0.9.0",
+    "apollo-server-errors": "^3.3.0",
+    "apollo-server-types": "^3.4.0",
     "undici": "^4.4.2"
+  },
+  "peerDependencies": {
+    "graphql": "^15.3.0 || ^16.0.0"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.9",
     "@types/node": "^14.17.3",
     "abort-controller": "^3.0.0",
-    "apollo-datasource-rest": "^0.14.0",
+    "apollo-datasource-rest": "^3.4.0",
     "ava": "^3.15.0",
-    "graphql": "^15.5.1",
+    "graphql": "^16.2.0",
     "h2url": "^0.2.0",
     "nock": "^13.1.1",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "apollo-server-caching": "^0.7.0",
     "apollo-server-errors": "^2.5.0",
     "apollo-server-types": "^0.9.0",
-    "graphql": "^15.5.1",
     "undici": "^4.4.2"
   },
   "devDependencies": {
@@ -63,6 +62,7 @@
     "abort-controller": "^3.0.0",
     "apollo-datasource-rest": "^0.14.0",
     "ava": "^3.15.0",
+    "graphql": "^15.5.1",
     "h2url": "^0.2.0",
     "nock": "^13.1.1",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-http",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "author": "Dustin Deus <deusdustin@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
:wave: Hello!

This brings two main changes:
1. Move `graphql` to `peerDependencies` (and `devDependencies`) to allow users of this package to choose for themselves. Apollo 3 itself allows either 15 or 16.
2. Upgrade all types to Apollo 3.

I believe this might cause a breaking change for some (all?) users of Apollo 2 so I've incremented the package version accordingly.